### PR TITLE
reduce image size by switching to alpine and reworking build order/cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,40 @@
-FROM buildpack-deps:jessie
+FROM alpine:3.5
 
 # Versions of Nginx and nginx-rtmp-module to use
 ENV NGINX_VERSION nginx-1.11.3
-ENV NGINX_RTMP_MODULE_VERSION 1.1.9
+ENV NGINX_RTMP_MODULE_VERSION 1.1.10
 
-# Install dependencies
-RUN apt-get update && \
-    apt-get install -y ca-certificates openssl libssl-dev && \
-    rm -rf /var/lib/apt/lists/*
+# Install necessary runtime packages
+RUN apk update \
+    && apk add openssl ca-certificates pcre
 
 # Download and decompress Nginx
-RUN mkdir -p /tmp/build/nginx && \
-    cd /tmp/build/nginx && \
-    wget -O ${NGINX_VERSION}.tar.gz https://nginx.org/download/${NGINX_VERSION}.tar.gz && \
-    tar -zxf ${NGINX_VERSION}.tar.gz
+RUN mkdir -p /tmp/build/nginx \
+    && cd /tmp/build/nginx \
+    && wget -O ${NGINX_VERSION}.tar.gz https://nginx.org/download/${NGINX_VERSION}.tar.gz \
+    && tar -zxf ${NGINX_VERSION}.tar.gz \
+    && rm ${NGINX_VERSION}.tar.gz
 
 # Download and decompress RTMP module
-RUN mkdir -p /tmp/build/nginx-rtmp-module && \
-    cd /tmp/build/nginx-rtmp-module && \
-    wget -O nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz https://github.com/arut/nginx-rtmp-module/archive/v${NGINX_RTMP_MODULE_VERSION}.tar.gz && \
-    tar -zxf nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz && \
-    cd nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}
+RUN mkdir -p /tmp/build/nginx-rtmp-module \
+    && cd /tmp/build/nginx-rtmp-module \
+    && wget -O nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz https://github.com/arut/nginx-rtmp-module/archive/v${NGINX_RTMP_MODULE_VERSION}.tar.gz \
+    && tar -zxf nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz \
+    && rm nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz \
+    && cd nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}
 
-# Build and install Nginx
-# The default puts everything under /usr/local/nginx, so it's needed to change
-# it explicitly. Not just for order but to have it in the PATH
-RUN cd /tmp/build/nginx/${NGINX_VERSION} && \
-    ./configure \
+# Build Nginx + RTMP module
+# - Install build dependencies (as virtual to facilitate removal afterwards)
+# - configure and build nginx + rtmp-module
+# - cleanup /tmp/build and build dependencies
+# all in one step to save on image layer size
+RUN apk add --virtual .build-dependencies \
+        gcc binutils-libs binutils build-base \
+        libgcc make pkgconf pkgconfig \
+        openssl-dev musl-dev \
+        libc-dev pcre-dev zlib-dev \
+    && cd /tmp/build/nginx/${NGINX_VERSION} \
+    && ./configure \
         --sbin-path=/usr/local/sbin/nginx \
         --conf-path=/etc/nginx/nginx.conf \
         --error-log-path=/var/log/nginx/error.log \
@@ -37,15 +45,16 @@ RUN cd /tmp/build/nginx/${NGINX_VERSION} && \
         --with-http_ssl_module \
         --with-threads \
         --with-ipv6 \
-        --add-module=/tmp/build/nginx-rtmp-module/nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION} && \
-    make -j $(getconf _NPROCESSORS_ONLN) && \
-    make install && \
-    mkdir /var/lock/nginx && \
-    rm -rf /tmp/build
+        --add-module=/tmp/build/nginx-rtmp-module/nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION} \
+    && make -j $(getconf _NPROCESSORS_ONLN) \
+    && make install \
+    && mkdir /var/lock/nginx \
+    && rm -rf /tmp/build \
+    && apk del .build-dependencies
 
 # Forward logs to Docker
-RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
-    ln -sf /dev/stderr /var/log/nginx/error.log
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
 
 # Set up config file
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,10 +1,15 @@
 worker_processes auto;
 rtmp_auto_push on;
+
+error_log  /var/log/nginx/error.log warn;
+
 events {}
 rtmp {
     server {
         listen 1935;
-        listen [::]:1935 ipv6only=on;    
+        listen [::]:1935 ipv6only=on;
+
+        access_log /var/log/nginx/access.log combined;
 
         application live {
             live on;


### PR DESCRIPTION
@tiangolo  in case you're interested in these changes.

Thanks for your work creating a generic container for the nginx rtmp module.  I was needing one and came across your implementation.   When I built it I noticed that it created a rather large image. (on my system it came out to 641.6 MB)  so i decided to rework the `Dockerfile` in an attempt to make it smaller.  Here's what I came up with... which reduced the image size down to 26.23 MB.

- switched to alpine 3.5
- updated version of nginx rtmp module to 1.1.10
- reworked build/cleanup order to reduce layer sizes
  - adds pkgs, builds and removes pkgs in a single step
- added explicit error/access log config to nginx.conf

these changes reduce the size of the docker image
from 600+ MB down to 26 MB.