### PR TITLE
✨ Allow using debug directives, enable ` --with-debug` compile option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN cd /tmp/build/nginx/${NGINX_VERSION} && \
         --with-http_ssl_module \
         --with-threads \
         --with-ipv6 \
-        --add-module=/tmp/build/nginx-rtmp-module/nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION} && \
+        --add-module=/tmp/build/nginx-rtmp-module/nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION} --with-debug && \
     make -j $(getconf _NPROCESSORS_ONLN) && \
     make install && \
     mkdir /var/lock/nginx && \


### PR DESCRIPTION
This allows debug information to be accessed by adding this directive to `nginx.conf`: 
```
error_log /var/log/nginx/error.log debug;
```
This is the recommended way based on the nginx-rtmp-module wiki: https://github.com/arut/nginx-rtmp-module/wiki/Debug-log