### PR TITLE
Use "STOPSIGNAL SIGQUIT"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,6 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
 COPY nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 1935
+
+STOPSIGNAL SIGQUIT
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Nginx should use `STOPSIGNAL SIGQUIT` for graceful shutdown.
Ref: https://github.com/nginxinc/docker-nginx/pull/457