### PR TITLE
⬆ Update RTMP module version to 1.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 # Versions of Nginx and nginx-rtmp-module to use
 ENV NGINX_VERSION nginx-1.18.0
-ENV NGINX_RTMP_MODULE_VERSION 1.2.1
+ENV NGINX_RTMP_MODULE_VERSION 1.2.2
 
 # Install dependencies
 RUN apt-get update && \


### PR DESCRIPTION
Hi @tiangolo,

I updated RTMP version to 1.2.2.
Thanks

refs: https://github.com/arut/nginx-rtmp-module/releases/tag/v1.2.2