### PR TITLE
Update example to serve the RTMP stream over HLS.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 # Versions of Nginx and nginx-rtmp-module to use
 ENV NGINX_VERSION nginx-1.18.0
-ENV NGINX_RTMP_MODULE_VERSION 1.2.1
+ENV NGINX_RTMP_MODULE_VERSION 1.2.2
 
 # Install dependencies
 RUN apt-get update && \
@@ -51,6 +51,10 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
 
 # Set up config file
 COPY nginx.conf /etc/nginx/nginx.conf
+RUN mkdir -p /tmp/hls/live
 
+# RTMP
 EXPOSE 1935
+# HLS
+EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,14 +1,54 @@
 worker_processes auto;
 rtmp_auto_push on;
 events {}
+
+# See https://github.com/arut/nginx-rtmp-module for details.
 rtmp {
     server {
         listen 1935;
-        listen [::]:1935 ipv6only=on;    
+        listen [::]:1935 ipv6only=on;
 
         application live {
             live on;
             record off;
+
+            # record first 1K of stream
+            #record all;
+            #record_path /tmp/av;
+            #record_max_size 1K;
+
+            # append current timestamp to each flv
+            #record_unique on;
+
+            # publish only from localhost
+            #allow publish 127.0.0.1;
+            #deny publish all;
+
+            # this is the default, allow everyone to play
+            #allow play all;
+
+            # see http section related
+            hls on;
+            hls_path /tmp/hls/live;
+            hls_type live;
+            hls_fragment 5s;
+            hls_playlist_length 15s;
+        }
+    }
+}
+
+http {
+    server {
+        listen      8080;
+
+        location /live {
+            # Serve HLS fragments
+            types {
+                application/vnd.apple.mpegurl m3u8;
+                video/mp2t ts;
+            }
+            root /tmp/hls;
+            add_header Cache-Control no-cache;
         }
     }
 }


### PR DESCRIPTION
Also add some commented examples of some interesting RTMP config
options.

Adding HLS serving for example is useful for LG WebOS TV's, which don't
support RTMP natively, but do support HLS, by browsing to the m3u8
location. With this setup, one can stream to the TV, though with some
20-25 seconds of delay (as at least that much data is buffered in the
HLS playlist.. allegedly there are settings to change the stream type to
event, which might result in the client following more the latest chunk,
but I couldn't get that to work).