### PR TITLE
👷 Fix latest-changes checkout target

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ github.event.repository.default_branch }}
           # To allow latest-changes to commit to master
           token: ${{ secrets.NGINX_RTMP_DOCKER_LATEST_CHANGES }} # zizmor: ignore[secrets-outside-env]
           persist-credentials: true # required by tiangolo/latest-changes


### PR DESCRIPTION
## What changed

- Configure the `latest-changes` workflow checkout step to use the repository default branch explicitly.
- This keeps `pull_request_target` runs on trusted base-repository code when `actions/checkout@v7` is used.

## Why

`actions/checkout@v7` refuses fork PR code in trusted `pull_request_target` contexts. For merged PR release-note workflows, the safe target is the base repository default branch.

## Validation

- Ran `git diff --check` for the changed workflow.
- Verified the pattern end to end in `tiangolo/sandbox`.

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.
